### PR TITLE
changes to write access token to userspace

### DIFF
--- a/oauthenticator/hydroshare.py
+++ b/oauthenticator/hydroshare.py
@@ -162,8 +162,10 @@ class HydroShareOAuthenticator(OAuthenticator):
         # get the username variable from the response
         username = resp_json["username"]
         
-        # save toekn to users home dir
-        fname = '/userspace/%s/.hs_auth' % (username)
+        # save token to users home dir
+        self.log.info("ENVIRON: " + os.environ)
+        fname = os.path.join(os.environ['JUPYTER_USERSPACE_DIR_HOST'], username, '.hs_auth')
+        self.log.info("fname: " + fname)
         auth = (token_dict, os.getenv('HYDROSHARE_CLIENT_ID'))
         with open(fname, 'wb') as f:
             pickle.dump(auth, f, protocol=2)

--- a/oauthenticator/hydroshare.py
+++ b/oauthenticator/hydroshare.py
@@ -163,7 +163,7 @@ class HydroShareOAuthenticator(OAuthenticator):
         username = resp_json["username"]
         
         # save token to users home dir
-        self.log.info("ENVIRON: " + os.environ)
+        self.log.info("ENVIRON: " + str(os.environ))
         fname = os.path.join(os.environ['JUPYTER_USERSPACE_DIR_HOST'], username, '.hs_auth')
         self.log.info("fname: " + fname)
         auth = (token_dict, os.getenv('HYDROSHARE_CLIENT_ID'))

--- a/oauthenticator/hydroshare.py
+++ b/oauthenticator/hydroshare.py
@@ -26,6 +26,7 @@ from pwd import getpwnam
 import grp
 import shutil
 import requests
+import pickle
 
 # hold on the the next_url for redirecting after authentication
 next_url = None
@@ -139,11 +140,11 @@ class HydroShareOAuthenticator(OAuthenticator):
 
         resp = yield http_client.fetch(req)
 
-        resp_json = json.loads(resp.body.decode('utf8', 'replace'))
+        token_dict = json.loads(resp.body.decode('utf8', 'replace'))
 
-        self.log.debug('HydroShareCallbackHandler, response json: '+str(resp_json))
+        self.log.debug('HydroShareCallbackHandler, response json: ' + str(token_dict))
 
-        access_token = resp_json['access_token']
+        access_token = token_dict['access_token']
 
         # Determine who the logged in user is
         headers={"Accept": "application/json",
@@ -161,6 +162,12 @@ class HydroShareOAuthenticator(OAuthenticator):
         # get the username variable from the response
         username = resp_json["username"]
         
+        # save toekn to users home dir
+        fname = '/userspace/%s/.hs_auth' % (username)
+        auth = (token_dict, os.getenv('HYDROSHARE_CLIENT_ID'))
+        with open(fname, 'wb') as f:
+            pickle.dump(auth, f, protocol=2)
+
         userdict = {"name": username}
         userdict["auth_state"] = auth_state = {}
         auth_state['access_token'] = access_token

--- a/oauthenticator/hydroshare.py
+++ b/oauthenticator/hydroshare.py
@@ -163,8 +163,7 @@ class HydroShareOAuthenticator(OAuthenticator):
         username = resp_json["username"]
         
         # save token to users home dir
-        self.log.info("ENVIRON: " + str(os.environ))
-        fname = os.path.join(os.environ['JUPYTER_USERSPACE_DIR_HOST'], username, '.hs_auth')
+        fname = os.path.join(os.environ['JUPYTER_USERSPACE_DIR'], username, '.hs_auth')
         self.log.info("fname: " + fname)
         auth = (token_dict, os.getenv('HYDROSHARE_CLIENT_ID'))
         with open(fname, 'wb') as f:


### PR DESCRIPTION
These are the changes to write the users token and client ID into a hidden file in the users home directory.  This authentication information can then be used by nbfetch and other tools that access the hydroshare rest api.